### PR TITLE
Unsplash-text-color-issue

### DIFF
--- a/src/addons/Backgrounds/unsplash/index.jsx
+++ b/src/addons/Backgrounds/unsplash/index.jsx
@@ -6,10 +6,10 @@ import { now, addMinutesToDate } from 'utils/datetime';
 import { customPalette } from 'utils/initialPalatte';
 import imageOptimisation from 'utils/image';
 import config from 'config.json';
+import getPalette from 'utils/paletteFinder';
 import getRandomImage from './api';
 import './index.css';
 import Credits from './credits';
-import getPalette from '../../../utils/paletteFinder';
 
 function Unsplash({
   width, height, setThemeUpdate, children,

--- a/src/utils/paletteFinder.js
+++ b/src/utils/paletteFinder.js
@@ -18,7 +18,7 @@ export default function getPalette(url) {
     image.src = url;
     image.crossOrigin = 'Anonymous';
 
-    image.onload = () => {
+    image.onload = function onload() {
       const colorThief = new ColorThief();
       const palette = colorThief.getPalette(this, 3);
       // const result = _.uniq(palette, item => JSON.stringify(item));


### PR DESCRIPTION
We had an issue where color extracted from background image doesnt fill text.
I was a mistake made by me when changing to eslint airbnb